### PR TITLE
Tweaked metas and moved script to the bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,18 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-
   <title></title>
-
   <meta name="description" content="">
   <link rel="stylesheet" href="stylesheets/main.css">
 </head>
 <body>
   <!-- content -->
-
   <!-- <script src="javascript/main.js"></script> -->
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,14 +2,18 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title></title>
-  <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <title></title>
+
+  <meta name="description" content="">
   <link rel="stylesheet" href="stylesheets/main.css">
-  <!-- <script src="javascript/main.js"></script> -->
 </head>
 <body>
+  <!-- content -->
 
+  <!-- <script src="javascript/main.js"></script> -->
 </body>
 </html>


### PR DESCRIPTION
🐶 

For http-equiv="content-type", I like to use that because it's a little more reassuring, though not absolutely necessary.

For viewport, I like it at the top because it's more of a browser-compatibility-management thing, as opposed to the actually informational metadata stuff below title.

For scripts, it's generally good practice (except in some cases like when you're loading your content via JS, which is terrible practice itself anyway) to load it at the bottom so that it doesn't block the rendering of your content. CSS needs to stay at the top because unstyled HTML is ugly af.
